### PR TITLE
PyUp changes (with LTS Django).

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
-Django==1.8.6
-django-cors-headers==1.1.0
-djangorestframework==3.3.2
+Django==1.8.17
+django-cors-headers==2.0.2
+djangorestframework==3.5.4


### PR DESCRIPTION
Changes as per `pyup.io` but sticking the LTS release of Django.